### PR TITLE
Created tag component

### DIFF
--- a/resources/js/Layouts/Components/TagComponent.vue
+++ b/resources/js/Layouts/Components/TagComponent.vue
@@ -1,7 +1,7 @@
 <template>
 <span class="rounded-full items-center font-medium text-tagText border bg-tagBg border-tag px-3 text-sm mr-1 mb-1 h-8 inline-flex">
     {{ displayedText }}
-    <button type="button" @click="$emit('click', property)">
+    <button type="button" @click="this.method(property)">
         <XIcon class="ml-1 h-4 w-4 hover:text-error "/>
     </button>
 </span>
@@ -16,7 +16,8 @@ export default {
     components: {Button, XIcon},
     props: {
         property: String,
-        displayedText: String
+        displayedText: String,
+        method: { type: Function},
     }
 }
 </script>

--- a/resources/js/Layouts/Components/TagComponent.vue
+++ b/resources/js/Layouts/Components/TagComponent.vue
@@ -1,0 +1,26 @@
+<template>
+<span class="rounded-full items-center font-medium text-tagText border bg-tagBg border-tag px-3 text-sm mr-1 mb-1 h-8 inline-flex">
+    {{ displayedText }}
+    <button type="button" @click="$emit('click', property)">
+        <XIcon class="ml-1 h-4 w-4 hover:text-error "/>
+    </button>
+</span>
+</template>
+
+<script>
+import Button from "@/Jetstream/Button";
+import {XIcon} from "@heroicons/vue/outline";
+
+export default {
+    name: "TagComponent",
+    components: {Button, XIcon},
+    props: {
+        property: String,
+        displayedText: String
+    }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Areas/AreaManagement.vue
+++ b/resources/js/Pages/Areas/AreaManagement.vue
@@ -46,15 +46,7 @@
                                     </div>
 
                                     <div class="mt-2 mr-10 flex flex-wrap">
-                                        <span v-for="(category,index) in room_categories"
-                                              class="rounded-full items-center font-medium text-tagText
-                                            border bg-tagBg border-tag px-3 text-sm mr-1 mb-1 h-8 inline-flex">
-                                            {{ category.name }}
-                                            <button type="button" @click="deleteRoomCategory(category)">
-                                                <!--<span class="sr-only">Email aus Einladung entfernen</span>-->
-                                                <XIcon class="ml-1 h-4 w-4 hover:text-error "/>
-                                            </button>
-                                        </span>
+                                        <TagComponent v-for="category in room_categories" @click="deleteRoomCategory(category)" :displayed-text="category.name" :property="category"/>
                                     </div>
 
                                     <!-- Raumattribute -->
@@ -775,9 +767,11 @@ import {Link, useForm} from "@inertiajs/inertia-vue3";
 import draggable from "vuedraggable";
 import UserTooltip from "@/Layouts/Components/UserTooltip";
 import {Inertia} from "@inertiajs/inertia";
+import TagComponent from "@/Layouts/Components/TagComponent";
 
 export default defineComponent({
     components: {
+        TagComponent,
         AddButton,
         UserTooltip,
         SvgCollection,

--- a/resources/js/Pages/Areas/AreaManagement.vue
+++ b/resources/js/Pages/Areas/AreaManagement.vue
@@ -46,7 +46,7 @@
                                     </div>
 
                                     <div class="mt-2 mr-10 flex flex-wrap">
-                                        <TagComponent v-for="category in room_categories" @click="deleteRoomCategory(category)" :displayed-text="category.name" :property="category"/>
+                                        <TagComponent v-for="category in room_categories" :method="deleteRoomCategory" :displayed-text="category.name" :property="category"/>
                                     </div>
 
                                     <!-- Raumattribute -->


### PR DESCRIPTION
Habe es in AreaManagement.vue zum anzeigen der Raumkategorien testweise schonmal eingebunden, das sollte also passen, schau es dir gerne nochmal an. Nur property zu übergeben und dann {{property.name}} anzeigen zu lassen geht nicht, weil zB bei den Rooms im Kalenderfilter es ja dann property.label sein müsste, deshalb property und displayedText getrennt. 